### PR TITLE
feat: Patch `zutil` for macos clang 17

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -10,12 +10,14 @@ jobs:
         os:
           - windows-latest
           - macos-latest
+          - macos-13
+          - macos-15
           - ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
-          node-version: 18
+          node-version: 22
 
       - name: Install esy
         run: |

--- a/Utilities/cmzlib/zutil.h
+++ b/Utilities/cmzlib/zutil.h
@@ -137,17 +137,8 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
 #  endif
 #endif
 
-#if defined(MACOS) || defined(TARGET_OS_MAC)
+#if defined(MACOS)
 #  define OS_CODE  7
-#  ifndef Z_SOLO
-#    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
-#      include <unix.h> /* for fdopen */
-#    else
-#      ifndef fdopen
-#        define fdopen(fd,mode) NULL /* No fdopen() */
-#      endif
-#    endif
-#  endif
 #endif
 
 #ifdef __acorn


### PR DESCRIPTION
Macos sequoia updated to clang 17 in xcodes command line tools which broke cmake builds this is a small patch to `zutil` fixing it.

I also added some additional macos tests for different versions to ensure this isn't breaking anything in older versions.
